### PR TITLE
Add repository search to repository information

### DIFF
--- a/_includes/footer.liquid
+++ b/_includes/footer.liquid
@@ -12,7 +12,7 @@
 
       <form id="search-repository" action="{{ site.github.repository_url }}/search" method="GET">
         <input name="q" type="text" placeholder="Search source on GitHub">
-        <button type="Submit">Search</button>
+        <button type="Submit">{% include github-search.svg %} Search</button>
       </form>
 
     </section>

--- a/_includes/footer.liquid
+++ b/_includes/footer.liquid
@@ -9,6 +9,12 @@
         <li><a href="{{ site.github.repository_url }}/issues/">Issues</a></li>
         <li><a href="{{ site.github.repository_url }}/pulls/">Pull requests</a></li>
       </ul>
+
+      <form id="search-repository" action="{{ site.github.repository_url }}/search" method="GET">
+        <input name="q" type="text" placeholder="Search source on GitHub">
+        <button type="Submit">Search</button>
+      </form>
+
     </section>
   {% endif %}
 

--- a/_includes/github-search.svg
+++ b/_includes/github-search.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z"></path></svg>

--- a/assets/style.css
+++ b/assets/style.css
@@ -666,4 +666,7 @@ main .edit-links a svg {
   footer {
     page-break-after: always;
   }
+  #search-repository {
+    display: none;
+  }
 }

--- a/assets/style.css
+++ b/assets/style.css
@@ -152,6 +152,32 @@ a:hover {
 }
 
 /* 
+Buttons
+*/
+
+button, input {
+  font-family: inherit;
+  font-size: inherit;
+  margin-bottom: 0.5em;
+  padding: 0.5em;
+  display: inline-block;
+  background: none;
+  border: 1px solid lightgrey;
+  border-radius: 2px;
+  white-space: nowrap;
+}
+input:focus, button:focus {
+  border: 1px solid black;
+  background: whitesmoke;
+}
+button:hover {
+  background: whitesmoke;
+}
+button svg {
+  vertical-align: -2px;
+}
+
+/* 
  * general layout
 */
 
@@ -660,6 +686,9 @@ main .edit-links a svg {
   footer section {
     padding: 1rem;
     max-width: 20rem;
+  }
+  #search-repository>button {
+    border-bottom-color: blue;
   }
 }
 @media print {


### PR DESCRIPTION
This search bar:

* Uses GitHub's repository search page to search for
  code, issues and pull requests
* Does not display on print media

So how this works:

1. You enter what you want to search for
2. GitHub opens on it's search page for that repository

So for example, on the about.publiccode.net you search for `contact`, it takes you to <https://github.com/publiccodenet/about/search?q=contact>

Closes #39 made by @felixfaassen and me.

![image](https://user-images.githubusercontent.com/1917629/84871080-654bf280-b080-11ea-9ca7-7467a9dcbafe.png)