### PR TITLE
Update /careers theme footer link

### DIFF
--- a/_includes/theme-footer.liquid
+++ b/_includes/theme-footer.liquid
@@ -13,7 +13,7 @@
     <p>More on <a href="https://projects.publiccode.net">projects.publiccode.net</a></p>
   </section>
   <section>
-    <h3><a href="https://publiccode.net/careers/">Careers</a></h3>
+    <h3><a href="https://publiccode.net/who-we-are/careers/">Careers</a></h3>
     <p>Calling all publicly minded open source people! Join our staff.</p>
     <p><a href="https://publiccode.net/careers/">About working with us and open positions</a></p>
   </section>


### PR DESCRIPTION
Update theme footer link from https://publiccode.net/careers/ to https://publiccode.net/who-we-are/careers/

ONLY MERGE AFTER [publiccode.net PR 99](https://github.com/publiccodenet/publiccode.net/pull/99). Travis will block this until that happens.

This change reflects a new folder structure on publiccode.net.