### PR TITLE
Remove empty table and adding extra conditions for its display

### DIFF
--- a/_includes/metadata.liquid
+++ b/_includes/metadata.liquid
@@ -1,8 +1,10 @@
 {% capture currentDate %}{{ site.time | date: '%F' }}{% endcapture %}
 {% capture date %}{{ page.expires | date: '%F' }}{% endcapture %}
 
-{% if page.type or page.explains or page.audience or page.author %}
+{% if page.type %}
   <h2 id="page-metadata">This {{ page.type | downcase }}</h2>
+{% endif %}
+{% if post.date or page.date or page.explains or page.audience or page.author or page.expires %}
   <table class="metadata">
     {% if post.date %}<tr><td>Date:</td><td>{{ post.date | date: '%-d %B %Y' }}</td></tr>{% endif %}
     {% if page.date %}<tr><td>Date:</td><td>{{ page.date | date: '%-d %B %Y' }}</td></tr>{% endif %}

--- a/_includes/page-information.liquid
+++ b/_includes/page-information.liquid
@@ -2,7 +2,7 @@
 
   {% include metadata.liquid %}
 
-  {% if page.toc != false and site.toc == true or page.toc == true %}
+  {% if page.toc == true and site.toc == true %}
     {% capture toc %}{% include toc.liquid html=content h_min=2 sanitize=true class="table-of-contents" ordered=true %}{% endcapture %}
 
     {% if toc != blank %}


### PR DESCRIPTION
## Description

While auditing the Public Code websites I think I found a little issue in the metadata sidebar: On several pages an empty table is displayed.

### Steps to reproduce

Inspect the sidebar on these pages for example:

- https://about.publiccode.net/
- https://about.publiccode.net/activities/
- https://about.publiccode.net/activities/documentation/

![image](https://user-images.githubusercontent.com/1919011/95585068-fb949180-0a3e-11eb-87b1-c11d130f1782.png)

### Expected result

For the title:
I have been assuming that the intended behaviour is to keep the ability to display a title even if the table below is empty (as it seems to be currently the case on https://about.publiccode.net/)
For the table itself:
I have been assuming that: this table should only be displayed if there is at least one field in it.