### PR TITLE
Add release information

### DIFF
--- a/_includes/footer.liquid
+++ b/_includes/footer.liquid
@@ -1,4 +1,29 @@
 <footer id="site-footer">
+  <!-- Release information -->
+  {% if site.github and site.github.releases and site.github.releases[0] %}
+    <section>
+      {% assign latestRelease = site.github.releases[0] %}
+
+      <h3>Version {{ latestRelease.tag_name }}{% if latestRelease.prerelease == true %} (pre-release){% endif %}</h3>
+      <p>Published <a href="{{ latestRelease.html_url }}">{{ latestRelease.published_at | date_to_long_string }} on GitHub</a></p>
+      <p>{{ latestRelease.name }}</p>
+
+      <ul>
+        {% for asset in latestRelease.assets %}
+          <li>
+            <a href="{{ asset.browser_download_url }}" download><code>{{ asset.name }}</code></a>
+          </li>
+        {% endfor %}
+        <li>
+          Source archive in 
+          <a href="{{ latestRelease.zipball_url }}" download><code>.zip</code></a>
+          or
+          <a href="{{ latestRelease.tarball_url }}" download><code>.tar.gz</code></a>
+        </li>
+      </ul>
+    </section>
+  {% endif %}
+
   <!-- GitHub repository information -->
   {% if site.github %}
     <section>

--- a/_includes/footer.liquid
+++ b/_includes/footer.liquid
@@ -1,5 +1,6 @@
 <footer id="site-footer">
-  <!-- GitHub repository information -->{% if site.github %}
+  <!-- GitHub repository information -->
+  {% if site.github %}
     <section>
       <h3>This site on GitHub</h3>
       <p>This site was last published {{ site.time | date_to_long_string }} from the <a href="{{ site.github.repository_url }}">{{ site.github.repository_nwo }}</a> repository on GitHub.</p>


### PR DESCRIPTION

Using the GitHub information available in Jekyll.

This means that it will always show the release information available at build time.
This means it is wise to make a release on your release branch
before merging to the branch Jekyll builds from.

Features:

* Tag and prerelease status in header
* Publishing date and GitHub release page link
* Release name in own paragraph
* Assets as download links