### PR TITLE
Publiccode.net new theme footer design

### DIFF
--- a/_includes/theme-footer.liquid
+++ b/_includes/theme-footer.liquid
@@ -1,35 +1,70 @@
 {% if site.hide_foundation_footer != true %}
 <footer id="foundation-footer">
-  <section>
-    <h3>
-    <a href="https://about.publiccode.net">About us</a>
-    </h3>
-    <p>Together, we’re growing an ecosystem of open public-purpose software and policy.</p>
-    <p>More on <a href="https://about.publiccode.net">about.publiccode.net</a></p>
-  </section>
-  <section>
-    <h3><a href="https://projects.publiccode.net">Our projects</a></h3>
-    <p>Open products we're researching or developing to further our mission.</p>
-    <p>More on <a href="https://projects.publiccode.net">projects.publiccode.net</a></p>
-  </section>
-  <section>
-    <h3><a href="https://publiccode.net/careers/">Careers</a></h3>
-    <p>Calling all publicly minded open source people! Join our staff.</p>
-    <p><a href="https://publiccode.net/careers/">About working with us and open positions</a></p>
-  </section>
-  <section>
-    <h3><a href="https://about.publiccode.net/organization/contact-details.html">Contact</a></h3>
-    <ul>
-      <li>Join our <a href="https://forms.gle/gn7wR2Eaxbv5g1BF9">mailing list</a>
-      <li>Phone: <a href="tel:+31202444500">+31 20 2 444 500</a>
-      <li>Email: <a href="mailto:info@publiccode.net">info@publiccode.net</a></li>
-      <li>Address:
-      <address>
-        Keizersgracht 617, 1017 DS, Amsterdam, the Netherlands
-      </address></li>
-    </ul>
-  </section>
-  <section>
-    <p>Foundation for Public Code vereniging (met volledige rechtsbevoegdheid) <a href="https://about.publiccode.net/organization/governance-model.html" title="Governance model">is a member owned association</a> registered under <a href="https://www.kvk.nl/orderstraat/product-kiezen/?kvknummer=74996452" title="KVK registration">chamber of commerce (KvK) registration 74996452</a> and with identification number (RSIN) 860102294. We're recognized as a <a href="https://www.belastingdienst.nl/wps/wcm/connect/bldcontenten/belastingdienst/business/business-public-benefit-organisations/public_benefit_organisations/what_is_pbo/what_is_a_pbo" title="public benefit organization (ANBI)">public benefit organization (ANBI)</a> by the Dutch Tax and Customs Administration.</p>  </section>
+
+  <div class="footer-trio">
+    <section>
+      <div class="footer-section-content">
+        <h2>How-to</h2>
+        <p>All of our staff information, decision-making rules and processes. Our staff manual is developed collaboratively with the community and can be reused by everyone.</p>
+        <p>Read more about our activities, organization, and the glossary of terms and concepts.</p>
+      </div>
+      <div class="footer-links">
+        <a href="https://about.publiccode.net">Get meta</a>
+      </div>
+    </section>
+    <section>
+      <div class="footer-section-content">
+        <h2>Project resources</h2>
+        <p>Open products we're researching or developing to further our mission. We rely on these resources for our everyday work. You can, too!</p>
+      </div>
+      <div class="footer-links">
+        <a href="https://projects.publiccode.net">Free to use and modify</a>
+        <a href="https://github.com/publiccodenet">See all our work on Github</a>
+      </div>
+    </section>
+    <section>
+      <div class="footer-section-content">
+        <h2>Careers</h2>
+        <p>Calling all publicly minded open source people! Find out about working with us, and join our staff.</p>
+      </div>
+      <div class="footer-links">
+        <a href="https://publiccode.net/careers/">Open positions</a>
+      </div>
+    </section>
+  </div>
+
+  <div class="footer-duo">
+    <section class="footer-contact">
+      <h2>Contact</h2>
+      <dl>
+          <dt>Newsletter:</dt>
+          <dd><a href="https://forms.gle/gn7wR2Eaxbv5g1BF9">Join our mailing list</a></dd>
+
+          <dt>Phone:</dt>
+          <dd><a href="tel:+31202444500">+31 20 2 444 500</a></dd>
+
+          <dt>Email:</dt>
+          <dd><a href="mailto:info@publiccode.net">info@publiccode.net</a></dd>
+
+          <dt>Address:</dt>
+          <dd><address>Keizersgracht 617, 1017 DS, Amsterdam, the Netherlands</address>
+          <a href="https://www.openstreetmap.org/node/2736377676" title="OpenStreetMap">OpenStreetMap</a> | <a href="https://www.google.com/maps/place/Keizersgracht+617,+1017+DS+Amsterdam,+Netherlands" title="Google Maps">Google</a>
+        </dd>
+
+          <dt>Twitter:</dt>
+          <dd><a href="https://twitter.com/publiccodenet">@publiccodenet</a></dd>
+      </dl>
+    </section>
+
+    <section class="footer-notes">
+      <h2>Organizational notes</h2>
+      <p>Foundation for Public Code vereniging (met volledige rechtsbevoegdheid) <a href="https://about.publiccode.net/organization/governance-model.html" title="Governance model">is a member owned association</a> registered under <a href="https://www.kvk.nl/orderstraat/product-kiezen/?kvknummer=74996452" title="KVK registration">chamber of commerce (KvK) registration 74996452</a> and with identification number (RSIN) 860102294.</p>
+      <p>We're recognized as a <a href="https://www.belastingdienst.nl/wps/wcm/connect/bldcontenten/belastingdienst/business/business-public-benefit-organisations/public_benefit_organisations/what_is_pbo/what_is_a_pbo" title="public benefit organization (ANBI)">public benefit organization (ANBI)</a> by the Dutch Tax and Customs Administration.</p>
+      <p class="footer-last-updated">Last updated {{ site.time | date_to_long_string }}</p>
+      <p class="footer-copyright">2020 <a href="https://publiccode.net">Foundation for Public Code</a></p>
+      <p class="footer-license"><a href="https://creativecommons.org/publicdomain/zero/1.0/" title="Creative Commons Zero v1.0 Universal">Creative Commons Zero v1.0 Universal</a></p>
+    </section>
+  </div>
+
 </footer>
 {% endif %}

--- a/_includes/theme-footer.liquid
+++ b/_includes/theme-footer.liquid
@@ -60,7 +60,6 @@
       <div class="footer-note-cluster"></div>
         <p class="footer-last-updated">Last updated {{ site.time | date_to_long_string }}</p>
         <p class="footer-copyright">2020 <a href="https://publiccode.net">Foundation for Public Code</a></p>
-        <p class="footer-license"><a href="https://creativecommons.org/publicdomain/zero/1.0/" title="Creative Commons Zero v1.0 Universal">Creative Commons Zero v1.0 Universal</a></p>
       </div>
     </section>
   </div>

--- a/_includes/theme-footer.liquid
+++ b/_includes/theme-footer.liquid
@@ -60,9 +60,11 @@
       <h2>Organizational notes</h2>
       <p>Foundation for Public Code vereniging (met volledige rechtsbevoegdheid) <a href="https://about.publiccode.net/organization/governance-model.html" title="Governance model">is a member owned association</a> registered under <a href="https://www.kvk.nl/orderstraat/product-kiezen/?kvknummer=74996452" title="KVK registration">chamber of commerce (KvK) registration 74996452</a> and with identification number (RSIN) 860102294.</p>
       <p>We're recognized as a <a href="https://www.belastingdienst.nl/wps/wcm/connect/bldcontenten/belastingdienst/business/business-public-benefit-organisations/public_benefit_organisations/what_is_pbo/what_is_a_pbo" title="public benefit organization (ANBI)">public benefit organization (ANBI)</a> by the Dutch Tax and Customs Administration.</p>
-      <p class="footer-last-updated">Last updated {{ site.time | date_to_long_string }}</p>
-      <p class="footer-copyright">2020 <a href="https://publiccode.net">Foundation for Public Code</a></p>
-      <p class="footer-license"><a href="https://creativecommons.org/publicdomain/zero/1.0/" title="Creative Commons Zero v1.0 Universal">Creative Commons Zero v1.0 Universal</a></p>
+      <div class="footer-note-cluster"></div>
+        <p class="footer-last-updated">Last updated {{ site.time | date_to_long_string }}</p>
+        <p class="footer-copyright">2020 <a href="https://publiccode.net">Foundation for Public Code</a></p>
+        <p class="footer-license"><a href="https://creativecommons.org/publicdomain/zero/1.0/" title="Creative Commons Zero v1.0 Universal">Creative Commons Zero v1.0 Universal</a></p>
+      </div>
     </section>
   </div>
 

--- a/_includes/theme-footer.liquid
+++ b/_includes/theme-footer.liquid
@@ -59,7 +59,7 @@
       <p>We're recognized as a <a href="https://www.belastingdienst.nl/wps/wcm/connect/bldcontenten/belastingdienst/business/business-public-benefit-organisations/public_benefit_organisations/what_is_pbo/what_is_a_pbo" title="public benefit organization (ANBI)">public benefit organization (ANBI)</a> by the Dutch Tax and Customs Administration.</p>
       <div class="footer-note-cluster"></div>
         <p class="footer-last-updated">Last updated {{ site.time | date_to_long_string }}</p>
-        <p class="footer-copyright">2020 <a href="https://publiccode.net">Foundation for Public Code</a></p>
+        <p class="footer-copyright">{{ 'now' | date: "%Y" }} <a href="https://publiccode.net">Foundation for Public Code</a></p>
       </div>
     </section>
   </div>

--- a/_includes/theme-footer.liquid
+++ b/_includes/theme-footer.liquid
@@ -49,10 +49,7 @@
           <dt>Address:</dt>
           <dd><address>Keizersgracht 617, 1017 DS, Amsterdam, the Netherlands</address>
           <a href="https://www.openstreetmap.org/node/2736377676" title="OpenStreetMap">OpenStreetMap</a> | <a href="https://www.google.com/maps/place/Keizersgracht+617,+1017+DS+Amsterdam,+Netherlands" title="Google Maps">Google</a>
-        </dd>
-
-          <dt>Twitter:</dt>
-          <dd><a href="https://twitter.com/publiccodenet">@publiccodenet</a></dd>
+          </dd>
       </dl>
     </section>
 

--- a/_includes/theme-footer.liquid
+++ b/_includes/theme-footer.liquid
@@ -4,7 +4,7 @@
   <div class="footer-trio">
     <section>
       <div class="footer-section-content">
-        <h2>How-to</h2>
+        <h2>About us</h2>
         <p>All of our staff information, decision-making rules and processes. Our staff manual is developed collaboratively with the community and can be reused by everyone.</p>
         <p>Read more about our activities, organization, and the glossary of terms and concepts.</p>
       </div>

--- a/assets/style.css
+++ b/assets/style.css
@@ -711,7 +711,7 @@ main .edit-links a svg {
 
   .footer-duo {
     width: 100%;
-    margin-top: 50px;
+    margin: 50px 0px;
     display: flex;
     flex-direction: row;
     justify-content: space-between;
@@ -751,6 +751,9 @@ main .edit-links a svg {
     max-width: none;
     padding-left: 30px;
     box-sizing: border-box;
+  }
+  .footer-note-cluster {
+    margin-top: 30px;
   }
   .footer-last-updated::before {
     content:'';

--- a/assets/style.css
+++ b/assets/style.css
@@ -3,7 +3,7 @@
 @import url('https://fonts.googleapis.com/css?family=Muli:400,400i,700');
 
 
-/* 
+/*
  * HTML and Body elements
 */
 
@@ -27,7 +27,7 @@ body, html {
     /* A4 with, for printing presses add a (3mm to each side) bleed here */
     size: 21cm 29.7cm;
     margin: 2cm 1cm;
-    orphans:4; 
+    orphans:4;
     widows:4;
     @bottom-center {
       background: whitesmoke;
@@ -35,13 +35,13 @@ body, html {
       content: counter(page);
       margin-top: 0.25cm;
       height: 1cm;
-      width: 1cm; 
+      width: 1cm;
       text-align: center;
     }
   }
 }
 
-/* 
+/*
  * General elements and ground rules
 */
 
@@ -82,7 +82,7 @@ img, code {
   }
 }
 
-/* 
+/*
  * Links
 */
 
@@ -151,7 +151,7 @@ a:hover {
   }
 }
 
-/* 
+/*
 Buttons
 */
 
@@ -177,7 +177,7 @@ button svg {
   vertical-align: -2px;
 }
 
-/* 
+/*
  * general layout
 */
 
@@ -208,7 +208,7 @@ body>hr {
   }
 }
 
-/* 
+/*
  * Foundation Navigation
 */
 
@@ -304,7 +304,7 @@ nav.theme-nav a.logo-mark>p {
   }
 }
 
-/* 
+/*
  * Site header
 */
 
@@ -346,7 +346,7 @@ header .site-title a:hover {
   }
 }
 
-/* 
+/*
  * Site navigation
 */
 
@@ -395,7 +395,7 @@ input#show-site-nav:checked ~ ul {
   }
 }
 
-/* 
+/*
  * Main content
 */
 
@@ -460,7 +460,7 @@ input#show-site-nav:checked ~ ul {
   }
 }
 
-/* 
+/*
  * Content
  */
 
@@ -489,9 +489,9 @@ main .content>article>:first-child:not(h1):not(h2):not(ol):not(ul) {
   .markdown-body {
     font-family: "Muli"
   }
-  
+
   .markdown-body h1, .markdown-body h2, .markdown-body h3 {
-    font-weight: normal; 
+    font-weight: normal;
     position: relative;
   }
   .markdown-body h1 {
@@ -520,7 +520,7 @@ main .content>article>:first-child:not(h1):not(h2):not(ol):not(ul) {
 
  @media screen {
   main section.page-information {
-    flex: 1 2 300px; 
+    flex: 1 2 300px;
     box-sizing: border-box;
     display: flex;
     flex-direction: column;
@@ -617,7 +617,7 @@ main .content>article>:first-child:not(h1):not(h2):not(ol):not(ul) {
   }
 }
 
-/* 
+/*
  * Edit links
 */
 
@@ -669,26 +669,154 @@ main .edit-links a svg {
   vertical-align: top;
 }
 
-/* 
+/*
  * Footer
  */
 
 @media screen {
-  footer {
+  .footer-trio {
+    width: 100%;
     display: flex;
     flex-direction: row;
-    align-items: flex-start;
-    justify-content: flex-start;
-    flex-wrap: wrap;
     justify-content: space-between;
-    padding: 1rem;
   }
-  footer section {
-    padding: 1rem;
-    max-width: 20rem;
+  .footer-trio section {
+    background: white;
+    width: calc(33.33% - 15px);
+    max-width: none;
+    padding: 30px;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
   }
+  .footer-trio h2 {
+    margin: 0px;
+  }
+  .footer-links {
+    text-align: right;
+  }
+  .footer-trio section a {
+    font-weight: 700;
+    text-decoration: none;
+    display: inline-block;
+    clear: both;
+    float: right;
+    margin-top: 15px;
+  }
+  .footer-trio section a:after {
+    content: '>';
+    padding-left: 8px;
+  }
+
+  .footer-duo {
+    width: 100%;
+    margin-top: 50px;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+  }
+  .footer-contact {
+    width: calc(33.33% - 15px);
+    max-width: none;
+    padding-left: 30px;
+    box-sizing: border-box;
+  }
+  .footer-contact dl {
+    width: 100%;
+    display: flex;
+    flex-flow: row;
+    flex-wrap: wrap;
+    overflow: visible;
+  }
+  .footer-contact dt {
+    font-weight: 700;
+    flex: 0 0 100px;
+  }
+  .footer-contact dd {
+    margin-left: auto;
+    text-align: left;
+    flex: 0 0 calc(100% - 100px);
+    display: block;
+    padding-bottom: 1em;
+  }
+  .footer-contact dd a {
+  }
+  .footer-contact dd address {
+    font-style: normal;
+  }
+
+  .footer-notes {
+    width: calc(66.67% - 7.5px);
+    max-width: none;
+    padding-left: 30px;
+    box-sizing: border-box;
+  }
+  .footer-last-updated::before {
+    content:'';
+    background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' x='0px' y='0px' width='16px' height='16px' viewBox='0 0 16 16' style='overflow:visible;enable-background:new 0 0 16 16;' xml:space='preserve' aria-hidden='true'%3e%3cpath fill-rule='evenodd' fill='black' d='M1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0zM8 0a8 8 0 100 16A8 8 0 008 0zm.5 4.75a.75.75 0 00-1.5 0v3.5a.75.75 0 00.471.696l2.5 1a.75.75 0 00.557-1.392L8.5 7.742V4.75z'%3e%3c/path%3e%3c/svg%3e");
+    background-repeat: no-repeat;
+    width: 16px;
+    height: 16px;
+    position: relative;
+    margin-right: 8px;
+    display: inline-block;
+    transform: translateY(3px);
+  }
+  .footer-copyright::before {
+    content:'';
+    background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' x='0px' y='0px' width='16px' height='16px' viewBox='0 0 16 16' style='overflow:visible;enable-background:new 0 0 16 16;' xml:space='preserve' aria-hidden='true'%3e%3cpath fill='black' d='M1.5,8c0-1.7,0.7-3.4,1.9-4.6C4.6,2.2,6.3,1.5,8,1.5s3.4,0.7,4.6,1.9c1.2,1.2,1.9,2.9,1.9,4.6s-0.7,3.4-1.9,4.6 S9.7,14.5,8,14.5s-3.4-0.7-4.6-1.9C2.2,11.4,1.5,9.7,1.5,8z M8,0C5.9,0,3.8,0.8,2.3,2.3C0.8,3.8,0,5.9,0,8c0,2.1,0.8,4.2,2.3,5.7 C3.8,15.2,5.9,16,8,16c2.1,0,4.2-0.8,5.7-2.3C15.2,12.2,16,10.1,16,8c0-2.1-0.8-4.2-2.3-5.7C12.2,0.8,10.1,0,8,0z'/%3e%3cpath fill='black' class='st0' d='M8,5.8c-1.2,0-2.2,1-2.2,2.2s1,2.2,2.2,2.2c0.6,0,1.1-0.2,1.5-0.6c0.3-0.3,0.8-0.3,1.1,0c0.3,0.3,0.3,0.8,0,1.1 c-0.7,0.6-1.6,1-2.6,1c-2.1,0-3.7-1.7-3.7-3.8c0-2.1,1.6-3.8,3.7-3.8c1,0,1.9,0.4,2.6,1c0.3,0.3,0.3,0.8,0,1.1 c-0.3,0.3-0.8,0.3-1.1,0C9.1,6,8.5,5.8,8,5.8z'/%3e%3c/svg%3e");
+    background-repeat: no-repeat;
+    width: 16px;
+    height: 16px;
+    position: relative;
+    margin-right: 8px;
+    display: inline-block;
+    transform: translateY(3px);
+  }
+  .footer-license::before {
+    content:'';
+    background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' x='0px' y='0px' width='16px' height='16px' viewBox='0 0 16 16' style='overflow:visible;enable-background:new 0 0 16 16;' xml:space='preserve'  aria-hidden='true'%3e%3cpath fill-rule='evenodd' fill='black' d='M8.75.75a.75.75 0 00-1.5 0V2h-.984c-.305 0-.604.08-.869.23l-1.288.737A.25.25 0 013.984 3H1.75a.75.75 0 000 1.5h.428L.066 9.192a.75.75 0 00.154.838l.53-.53-.53.53v.001l.002.002.002.002.006.006.016.015.045.04a3.514 3.514 0 00.686.45A4.492 4.492 0 003 11c.88 0 1.556-.22 2.023-.454a3.515 3.515 0 00.686-.45l.045-.04.016-.015.006-.006.002-.002.001-.002L5.25 9.5l.53.53a.75.75 0 00.154-.838L3.822 4.5h.162c.305 0 .604-.08.869-.23l1.289-.737a.25.25 0 01.124-.033h.984V13h-2.5a.75.75 0 000 1.5h6.5a.75.75 0 000-1.5h-2.5V3.5h.984a.25.25 0 01.124.033l1.29.736c.264.152.563.231.868.231h.162l-2.112 4.692a.75.75 0 00.154.838l.53-.53-.53.53v.001l.002.002.002.002.006.006.016.015.045.04a3.517 3.517 0 00.686.45A4.492 4.492 0 0013 11c.88 0 1.556-.22 2.023-.454a3.512 3.512 0 00.686-.45l.045-.04.01-.01.006-.005.006-.006.002-.002.001-.002-.529-.531.53.53a.75.75 0 00.154-.838L13.823 4.5h.427a.75.75 0 000-1.5h-2.234a.25.25 0 01-.124-.033l-1.29-.736A1.75 1.75 0 009.735 2H8.75V.75zM1.695 9.227c.285.135.718.273 1.305.273s1.02-.138 1.305-.273L3 6.327l-1.305 2.9zm10 0c.285.135.718.273 1.305.273s1.02-.138 1.305-.273L13 6.327l-1.305 2.9z'%3e%3c/path%3e%3c/svg%3e");
+    background-repeat: no-repeat;
+    width: 16px;
+    height: 16px;
+    position: relative;
+    margin-right: 8px;
+    display: inline-block;
+    transform: translateY(3px);
+  }
+
   #search-repository>button {
     border-bottom-color: blue;
+  }
+
+  @media screen and (max-width: 1000px) {
+    .footer-contact dl {
+      flex-flow: column;
+    }
+    .footer-contact dt {
+      flex: 0 0 auto;
+    }
+    .footer-contact dd {
+      margin-left: 0;
+      flex: 0 0 auto;
+    }
+  }
+
+  @media screen and (max-width: 800px) {
+    .footer-trio {
+      flex-direction: column;
+    }
+    .footer-trio section {
+      width: 100%;
+      margin-bottom: 20px;
+    }
+    .footer-duo {
+      flex-direction: column;
+    }
+    .footer-duo section {
+      width: 100%;
+    }
   }
 }
 @media print {


### PR DESCRIPTION
**Housekeeping:** 
Transferred the footer update issue from _publiccode.net_ to _jekyll-theme_, as the affected files are both in the latter repo.

**Updated files:** 
1. Added structure and content to theme-footer.liquid, which contains the bottom-most footer (in the grey)
2. Added footer-related CSS code to main style.css. (Note: Written in plain CSS to stay consistent with existing code, not SCSS as with other updates).

**Considerations/Caveats:**
1. This includes some language changes (exactly as shown in the design comps in the issue), including most notably changing "About" to "How-to"
2. Though these files are contained in _jekyll-theme_, the update should be site-wide, as (if I am not mistaken) all subdomains make use of the same footer theme-footer.liquid file

**Travis status:**
Travis is only throwing a Twitter link exception (related to CONTRIBUTING.html), so either everything else is passing, or it's tripping on that exception and hasn't yet actually checked my code... 
https://travis-ci.com/github/publiccodenet/jekyll-theme/builds/213747432