### PR TITLE
Splitting nav mirroring into header (w/ nav) and footer (just logo)

### DIFF
--- a/_includes/theme-footer-logo.liquid
+++ b/_includes/theme-footer-logo.liquid
@@ -1,0 +1,6 @@
+<nav class="theme-nav">
+  <a href="https://publiccode.net/" title="Homepage of the Foundation for Public Code" class="logo-mark">
+    <img src="https://brand.publiccode.net/logo/mark.svg" alt="The mark of the Foundation for Public Code looks like a little greek temple, or government building, in a hexagon">
+    <p>Foundation for Public Code</p>
+  </a>
+</nav>

--- a/_layouts/theme.liquid
+++ b/_layouts/theme.liquid
@@ -6,10 +6,10 @@
   <body class="{% if page.toc != false and site.toc == true or page.toc == true %}with-toc{% endif %} {% if site.show_navigation == true %}with-site-nav{% endif %}">
 
     {% include theme-nav.liquid %}
-        
+
     {{ content }}
 
-    {% include theme-nav.liquid %}
+    {% include theme-footer-logo.liquid %}
 
     {% include theme-footer.liquid %}
 


### PR DESCRIPTION
**In order to:** 
1. Remove the nav links from the footer (https://github.com/publiccodenet/jekyll-theme/issues/41)
2. Retain the logo and links in the page header
3. Retain the logo in the footer

**And given that:** The nav bar is currently a single file mirrored in the header and footer...

**I have:**
1. Created a new footer file (_theme-footer-logo.liquid_) containing just the logo: 
2. Updated _theme.liquid_ to refer to this new file in the footer, while continuing to add the original theme-nav.liquid in the page header