### PR TITLE
Add site-wide license (+ caveat verbiage) to bottom of footer

### DIFF
--- a/_includes/theme-footer.liquid
+++ b/_includes/theme-footer.liquid
@@ -60,7 +60,8 @@
       <div class="footer-note-cluster"></div>
         <p class="footer-last-updated">Last updated {{ site.time | date_to_long_string }}</p>
         <p class="footer-copyright">{{ 'now' | date: "%Y" }} <a href="https://publiccode.net">Foundation for Public Code</a></p>
-      </div>
+        <p class="footer-license">All content licensed under <a href="https://creativecommons.org/publicdomain/zero/1.0/" title="Creative Commons Zero v1.0 Universal">Creative Commons Zero v1.0 Universal</a>, unless otherwise noted</p>
+        </div>
     </section>
   </div>
 


### PR DESCRIPTION
As discussed here: https://github.com/publiccodenet/jekyll-theme/issues/55