### PR TITLE
Improving 'About us' link title in footer

### DIFF
--- a/_includes/theme-footer.liquid
+++ b/_includes/theme-footer.liquid
@@ -9,7 +9,7 @@
         <p>Read more about our activities, organization, and the glossary of terms and concepts.</p>
       </div>
       <div class="footer-links">
-        <a href="https://about.publiccode.net">Get meta</a>
+        <a href="https://about.publiccode.net">How we work</a>
       </div>
     </section>
     <section>


### PR DESCRIPTION
Resolving Boris' concern about 'Get meta' wording being perceived as unserious.
https://github.com/publiccodenet/jekyll-theme/issues/62