### PR TITLE
Fix missing table of contents

### DIFF
--- a/_includes/page-information.liquid
+++ b/_includes/page-information.liquid
@@ -2,7 +2,7 @@
 
   {% include metadata.liquid %}
 
-  {% if page.toc == true and site.toc == true %}
+  {% if page.toc != false and site.toc == true or page.toc == true %}
     {% capture toc %}{% include toc.liquid html=content h_min=2 sanitize=true class="table-of-contents" ordered=true %}{% endcapture %}
 
     {% if toc != blank %}


### PR DESCRIPTION
The removed statement was actually necessary.
It enables overwriting the site wide setting per page.

The table of content stopped functioning entirely when not set per page and sitewide.

Fixes #69 