### PR TITLE
Add possibility to show badges in footer

### DIFF
--- a/_includes/footer.liquid
+++ b/_includes/footer.liquid
@@ -21,7 +21,7 @@
           <a href="{{ latestRelease.tarball_url }}" download><code>.tar.gz</code></a>
         </li>
       </ul>
-      {% if site.include_badges = true %}
+      {% if site.include_badges %}
       {% include badges.html %}
       {% endif %}
     </section>

--- a/_includes/footer.liquid
+++ b/_includes/footer.liquid
@@ -21,6 +21,9 @@
           <a href="{{ latestRelease.tarball_url }}" download><code>.tar.gz</code></a>
         </li>
       </ul>
+      {% if site.include_badges = true %}
+      {% include badges.html %}
+      {% endif %}
     </section>
   {% endif %}
 


### PR DESCRIPTION
Adding a variable that can be set in the _config.yml to show a html snippet with badges in the footer. The snippet is defined in a separate file and included.

Part of the solution for publiccodenet/standard#519