### PR TITLE
Add link to new mailing list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ We love issues and pull requests from everyone. If you're not comfortable with G
 ## Problems, suggestions and questions in issues
 
 Please help development by reporting problems, suggesting changes and asking questions. To do this, you can [create a GitHub issue](https://help.github.com/articles/creating-an-issue/) for this project in the [GitHub Issues for the Standard for Public Code](https://github.com/publiccodenet/standard/issues).
+Or, sign up to the [mailing list](https://lists.publiccode.net/mailman/postorius/lists/jekyll-theme-discuss.lists.publiccode.net/) and send an email to [standard@lists.publiccode.net](mailto:jekyll-theme-discuss@lists.publiccode.net).
 
 You don't need to change any of our code or documentation to be a contributor!
 


### PR DESCRIPTION
Fixes #30

-----
[View rendered CONTRIBUTING.md](https://github.com/publiccodenet/jekyll-theme/blob/ja-mailing-list/CONTRIBUTING.md)