### PR TITLE
Add prev-next navigation if show_prev_next: true

### DIFF
--- a/_includes/prev_next.liquid
+++ b/_includes/prev_next.liquid
@@ -1,0 +1,15 @@
+<span id="span-prev-next" class="theme-prev-next">
+{% assign prev_order = page.order | minus:1 %}
+{% assign next_order = page.order | plus:1 %}
+{% assign sorted = site.pages | sort:"order" %}
+{% for otherpage in sorted %}
+{% if otherpage.order == prev_order %}
+<span id="span-prev" class="theme-prev-next-prev"><a
+href="{{ otherpage.url }}">&#8592; {{ otherpage.title }}</a></span>
+{% endif %}
+{% if otherpage.order == next_order %}
+<span id="span-next" class="theme-prev-next-next"><a
+href="{{ otherpage.url }}">{{ otherpage.title }} &#8594;</a></span>
+{% endif %}
+{% endfor %}
+</span><!-- span-prev-next -->

--- a/_layouts/single-page.liquid
+++ b/_layouts/single-page.liquid
@@ -4,6 +4,10 @@ layout: site
 
 <main>
 
+   {% if page.show_prev_next %}
+      {% include prev_next.liquid %}
+   {% endif %}
+
   {% if site.show_breadcrumbs %}
     {% include breadcrumbs.liquid %}
   {% endif %}

--- a/assets/style.css
+++ b/assets/style.css
@@ -448,6 +448,18 @@ input#show-site-nav:checked ~ ul {
     flex-basis: 100%;
     order: 0;
   }
+  main .theme-prev-next {
+    flex-basis: 100%;
+    order: 0;
+  }
+  main .theme-prev-next-prev {
+    float:left;
+    margin-right: 5px;
+  }
+  main .theme-prev-next-next {
+    float:right;
+    margin-left: 5px;
+  }
   main>h1 {
     flex-basis: 100%;
     margin: 0;


### PR DESCRIPTION
Pages must be part of a list which have an 'order' attribute.
A link will be created to the page with an 'order' attribute of 1
less than the current page 'order', if such a page is in the list.
Also, a link will be created to the page which has an order of 1
greater, if it exists.