### PR TITLE
Remove long alt tag on mark for accessibility

### DIFF
--- a/_includes/theme-nav.liquid
+++ b/_includes/theme-nav.liquid
@@ -1,6 +1,6 @@
 <nav class="theme-nav">
   <a href="https://publiccode.net/" title="Homepage of the Foundation for Public Code" class="logo-mark">
-    <img src="https://brand.publiccode.net/logo/mark.svg" alt="The mark of the Foundation for Public Code looks like a little greek temple, or government building, in a hexagon">
+    <img src="https://brand.publiccode.net/logo/mark.svg" alt="Mark of the Foundation for Public Code">
     <p>Foundation for Public Code</p>
   </a>
   <ul>


### PR DESCRIPTION
Yes, it is fun to describe what the logo looks like, however for people with screen readers this might be tiresome to hear over and over.

Discovered using the WAVE accessibility tool: https://wave.webaim.org/report#/publiccode.net