### PR TITLE
Hide the mark from accessibility tools

### DIFF
--- a/_includes/theme-nav.liquid
+++ b/_includes/theme-nav.liquid
@@ -1,13 +1,13 @@
 <nav class="theme-nav">
   <a href="https://publiccode.net/" title="Homepage of the Foundation for Public Code" class="logo-mark">
-    <img src="https://brand.publiccode.net/logo/mark.svg" alt="The mark of the Foundation for Public Code looks like a little greek temple, or government building, in a hexagon">
+    <img src="https://brand.publiccode.net/logo/mark.svg" alt="The mark of the Foundation for Public Code looks like a little greek temple, or government building, in a hexagon" aria-hidden="true">
     <p>Foundation for Public Code</p>
   </a>
   <ul>
     <li><a href="https://publiccode.net/codebase-stewardship/" title="Codebase Stewardship">Stewardship</a></li>
     <li><a href="https://projects.publiccode.net/" title="Project Resources">Resources</a></li>
-    <li><a href="https://publiccode.net/team/" title="Who we are">Who we are</a></li>
-    <li><a href="https://about.publiccode.net/CONTRIBUTING.html" title="Join us">Join us</a></li>
+    <li><a href="https://publiccode.net/team/">Who we are</a></li>
+    <li><a href="https://about.publiccode.net/CONTRIBUTING.html">Join us</a></li>
     <li><a href="https://github.com/publiccodenet/" title="The Foundation for Public Code on Github"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="24px" height="24px" viewBox="0 0 24 24" style="overflow:visible;enable-background:new 0 0 24 24;" xml:space="preserve"><style type="text/css">.github-logo{fill-rule:evenodd;clip-rule:evenodd;fill:#24292E;transform:translateY(6px);}</style><path class="github-logo" d="M12,0C5.4,0,0,5.5,0,12.3c0,5.4,3.5,10,8.2,11.7C8.8,24.1,9,23.7,9,23.4c0-0.3,0-1.1,0-2.1 c-3.3,0.8-4-1.7-4-1.7c-0.5-1.4-1.3-1.8-1.3-1.8c-1.1-0.8,0.1-0.8,0.1-0.8c1.2,0.1,1.8,1.3,1.8,1.3c1.1,1.9,2.8,1.4,3.5,1.1 c0.1-0.8,0.4-1.4,0.7-1.7c-2.7-0.3-5.4-1.4-5.4-6.1c0-1.4,0.4-2.4,1.3-3.3C5.4,8.1,5,6.8,5.7,5.1c0,0,1-0.3,3.3,1.3 c1-0.3,2-0.4,3-0.4s2.1,0.2,3,0.4c2.3-1.6,3.3-1.3,3.3-1.3c0.7,1.7,0.2,2.9,0.1,3.2c0.7,0.8,1.3,2,1.3,3.3c0,4.8-2.8,5.7-5.4,6 c0.4,0.4,0.8,1.1,0.8,2.3c0,1.7,0,2.9,0,3.4c0,0.3,0.2,0.7,0.8,0.6c4.8-1.7,8.2-6.3,8.2-11.7C24,5.5,18.6,0,12,0z"/></svg></a></li>
   </ul>
 </nav>


### PR DESCRIPTION
As suggested by @Ainali in #75

Also removed redundant 'Title' tags, as suggested by WAVE: https://wave.webaim.org/report#/publiccode.net