### PR TITLE
Include site.baseurl in header

### DIFF
--- a/_includes/header.liquid
+++ b/_includes/header.liquid
@@ -1,7 +1,7 @@
 <header>
   {% if site.title %}
     <section class="site-title {% if page.url == '/' %} home {% endif %}">
-      <a href="{{ site.url }}">{{ site.title }}</a>
+      <a href="{{ site.url }}{{ site.baseurl }}">{{ site.title }}</a>
     </section>
   {% endif %}
 


### PR DESCRIPTION
See: https://mademistakes.com/mastering-jekyll/site-url-baseurl/
for a good diagram of site.url, site.baseurl and page.url

Co-authored-by: Jan Ainali <ainali.jan@gmail.com>