### PR TITLE
Add link to all releases

### DIFF
--- a/_includes/footer.liquid
+++ b/_includes/footer.liquid
@@ -15,6 +15,9 @@
           </li>
         {% endfor %}
         <li>
+            <a href="{{ site.github.repository_url }}/releases">All releases</a>
+        </li>
+        <li>
           Source archive in 
           <a href="{{ latestRelease.zipball_url }}" download><code>.zip</code></a>
           or


### PR DESCRIPTION
Fixes #90

There might be a more direct and future-proof way to solve this, possibly through `{{ site.github.releases_html_url }}`, but it is hard to test since this repository doesn't have any releases. And my solution works until GitHub decides to put the releases under another URL than just `/releases`.