### PR TITLE
Change parameter name and referral

### DIFF
--- a/_includes/page-information.liquid
+++ b/_includes/page-information.liquid
@@ -11,7 +11,7 @@
     {% endif %}
   {% endif %}
 
-  {% if feed == true %}
+  {% if site.feed_link == true %}
       <h3 id="page-feed">Feed</h3>
       <a href="{{ site.url }}/feed">Subscription feed</a>
   {% endif %}


### PR DESCRIPTION
`feed` could not be used since it is reserved for jekyll-feed and `site.` was needed to make it match.