### PR TITLE
Correcting link target of feed

### DIFF
--- a/_includes/page-information.liquid
+++ b/_includes/page-information.liquid
@@ -13,7 +13,7 @@
 
   {% if site.feed_link == true %}
       <h3 id="page-feed">Feed</h3>
-      <a href="{{ site.url }}/feed">Subscription feed</a>
+      <a href="{{ site.url }}/feed.xml">Subscription feed</a>
   {% endif %}
 
   {% if site.github.repository_url %}


### PR DESCRIPTION
This was an unfortunate mistake by me, but the feed is located at /feed.xml not just /feed