### PR TITLE
Add author info from data file

### DIFF
--- a/_includes/metadata.liquid
+++ b/_includes/metadata.liquid
@@ -1,6 +1,6 @@
 {% capture currentDate %}{{ site.time | date: '%F' }}{% endcapture %}
 {% capture date %}{{ page.expires | date: '%F' }}{% endcapture %}
-
+{% assign author = site.data.authors[page.author] %}
 {% if page.type %}
   <h2 id="page-metadata">This {{ page.type | downcase }}</h2>
 {% endif %}
@@ -10,7 +10,7 @@
     {% if page.date %}<tr><td>Date:</td><td>{{ page.date | date: '%-d %B %Y' }}</td></tr>{% endif %}
     {% if page.explains %}<tr><td>Explains:</td><td class="explains">{{page.explains}}</td></tr>{% endif %}
     {% if page.audience %}<tr><td>Audience:</td><td class="audience">{{page.audience}}</td></tr>{% endif %}
-    {% if page.author %}<tr><td>Author:</td><td class="author">{{page.author}}</td></tr>{% endif %}
+    {% if page.author %}<tr><td>Author:</td><td class="author">{{author.name}}</td></tr>{% endif %}
     {% if page.expires %}<tr class="{% if date < currentDate %}expired{% else %}not-expired{% endif %}"><td>Expires:</td><td class="expires">{{ page.expires | date: "%-d %B %Y" }} ({{page.expires}})</ttd></td>{% endif %}
   </table>
 {% endif %}


### PR DESCRIPTION
This allows us to in the blog to get more metadata about authors in the feed. (We need to change that csv to yml though).

This change can be tested locally by adding the frontmatter 

```
---
author: Jan Ainali
---
```

to one file (for example [governance.md](https://github.com/publiccodenet/jekyll-theme/blob/master/governance.md)), then adding a folder named `_data` and add a file `authors.yml` in it. That file can have content like this:

```
Jan Ainali:
    name: Ainali
    twitter: Jan_Ainali
```

When serving the site, and viewing the file the addition was made to, the Author should be shown as "Ainali", not "Jan Ainali".

One can also check another page to make sure Author does not show up.