### PR TITLE
adds redirect guide to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ sitemap: false
 redirect_to: https://example.net/some-url
 ```
 
+This is how we [redirect pages](https://about.publiccode.net/about/activities/documentation).
+
 ### Foundation for Public Code footer
 
 You can remove the footer with the contact information and higher level navigation to the footer by setting `hide_foundation_footer: true` in the `_config.yml`.


### PR DESCRIPTION
Thought this might be handy to have here?

-----
[View rendered README.md](https://github.com/publiccodenet/jekyll-theme/blob/adds_redirect_instructions_to_README/README.md)