### PR TITLE
Add non breaking spaces to name

### DIFF
--- a/_includes/theme-nav.liquid
+++ b/_includes/theme-nav.liquid
@@ -1,7 +1,7 @@
 <nav class="theme-nav">
   <a href="https://publiccode.net/" title="Homepage of the Foundation for Public Code" class="logo-mark">
     <img src="https://brand.publiccode.net/logo/mark.svg" alt="The mark of the Foundation for Public Code looks like a little greek temple, or government building, in a hexagon" aria-hidden="true">
-    <p>Foundation for Public Code</p>
+    <p>Foundation&nbsp;for Public&nbsp;Code</p>
   </a>
   <ul>
     <li><a href="https://publiccode.net/codebase-stewardship/" title="Codebase Stewardship">Stewardship</a></li>


### PR DESCRIPTION
In order to make the line break follow the instructions in https://brand.publiccode.net/name/ non-breaking spaces have been added between Foundation and for, and between Public and Code.